### PR TITLE
Convert max energy to minimum light size in shader

### DIFF
--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -6502,7 +6502,7 @@ void RendererSceneRenderRD::_setup_lights(const PagedArray<RID> &p_lights, const
 		light_data.atlas_rect[2] = 0;
 		light_data.atlas_rect[3] = 0;
 
-		light_data.max_energy = storage->light_get_param(base, RS::LIGHT_PARAM_MAX_ENERGY);
+		light_data.min_size = Math::pow(storage->light_get_param(base, RS::LIGHT_PARAM_MAX_ENERGY), -light_data.attenuation);
 
 		RID projector = storage->light_get_projector(base);
 

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.h
@@ -1376,7 +1376,7 @@ private:
 			float soft_shadow_scale;
 			uint32_t mask;
 			float shadow_volumetric_fog_fade;
-			float max_energy;
+			float min_size;
 			float projector_rect[4];
 		};
 

--- a/servers/rendering/renderer_rd/shaders/cluster_data_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/cluster_data_inc.glsl
@@ -27,7 +27,7 @@ struct LightData { //this structure needs to be as packed as possible
 	float soft_shadow_scale; // scales the shadow kernel for blurrier shadows
 	uint mask;
 	float shadow_volumetric_fog_fade;
-	float max_energy;
+	float min_size;
 	vec4 projector_rect; //projector rect in srgb decal atlas
 };
 

--- a/servers/rendering/renderer_rd/shaders/scene_forward.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward.glsl
@@ -904,13 +904,13 @@ float sample_directional_soft_shadow(texture2D shadow, vec3 pssm_coord, vec2 tex
 
 #endif //USE_NO_SHADOWS
 
-float get_omni_attenuation(float distance, float inv_range, float decay, float max_energy) {
+float get_omni_attenuation(float distance, float inv_range, float decay, float min_size) {
 	float nd = distance * inv_range;
 	nd *= nd;
 	nd *= nd; // nd^4
 	nd = max(1.0 - nd, 0.0);
 	nd *= nd; // nd^2
-	return min(nd * pow(max(distance, 0.0001), -decay), max_energy);
+	return nd * pow(max(distance, min_size), -decay);
 }
 
 float light_process_omni_shadow(uint idx, vec3 vertex, vec3 normal) {
@@ -1082,7 +1082,7 @@ void light_process_omni(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 v
 		inout vec3 diffuse_light, inout vec3 specular_light) {
 	vec3 light_rel_vec = omni_lights.data[idx].position - vertex;
 	float light_length = length(light_rel_vec);
-	float omni_attenuation = get_omni_attenuation(light_length, omni_lights.data[idx].inv_radius, omni_lights.data[idx].attenuation, omni_lights.data[idx].max_energy);
+	float omni_attenuation = get_omni_attenuation(light_length, omni_lights.data[idx].inv_radius, omni_lights.data[idx].attenuation, omni_lights.data[idx].min_size);
 	float light_attenuation = omni_attenuation;
 	vec3 color = omni_lights.data[idx].color;
 
@@ -1335,7 +1335,7 @@ void light_process_spot(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 v
 		inout vec3 specular_light) {
 	vec3 light_rel_vec = spot_lights.data[idx].position - vertex;
 	float light_length = length(light_rel_vec);
-	float spot_attenuation = get_omni_attenuation(light_length, spot_lights.data[idx].inv_radius, spot_lights.data[idx].attenuation, spot_lights.data[idx].max_energy);
+	float spot_attenuation = get_omni_attenuation(light_length, spot_lights.data[idx].inv_radius, spot_lights.data[idx].attenuation, spot_lights.data[idx].min_size);
 	vec3 spot_dir = spot_lights.data[idx].direction;
 	float scos = max(dot(-normalize(light_rel_vec), spot_dir), spot_lights.data[idx].cone_angle);
 	float spot_rim = max(0.0001, (1.0 - scos) / (1.0 - spot_lights.data[idx].cone_angle));

--- a/servers/rendering/renderer_rd/shaders/volumetric_fog.glsl
+++ b/servers/rendering/renderer_rd/shaders/volumetric_fog.glsl
@@ -193,13 +193,13 @@ vec3 hash3f(uvec3 x) {
 	return vec3(x & 0xFFFFF) / vec3(float(0xFFFFF));
 }
 
-float get_omni_attenuation(float distance, float inv_range, float decay, float max_energy) {
+float get_omni_attenuation(float distance, float inv_range, float decay, float min_size) {
 	float nd = distance * inv_range;
 	nd *= nd;
 	nd *= nd; // nd^4
 	nd = max(1.0 - nd, 0.0);
 	nd *= nd; // nd^2
-	return min(nd * pow(max(distance, 0.0001), -decay), max_energy);
+	return nd * pow(max(distance, min_size), -decay);
 }
 
 void cluster_get_item_range(uint p_offset, out uint item_min, out uint item_max, out uint item_from, out uint item_to) {
@@ -417,7 +417,7 @@ void main() {
 				float shadow_attenuation = 1.0;
 
 				if (d * omni_lights.data[light_index].inv_radius < 1.0) {
-					float attenuation = get_omni_attenuation(d, omni_lights.data[light_index].inv_radius, omni_lights.data[light_index].attenuation, omni_lights.data[light_index].max_energy);
+					float attenuation = get_omni_attenuation(d, omni_lights.data[light_index].inv_radius, omni_lights.data[light_index].attenuation, omni_lights.data[light_index].min_size);
 
 					vec3 light = omni_lights.data[light_index].color / M_PI;
 
@@ -503,7 +503,7 @@ void main() {
 				float shadow_attenuation = 1.0;
 
 				if (d * spot_lights.data[light_index].inv_radius < 1.0) {
-					float attenuation = get_omni_attenuation(d, spot_lights.data[light_index].inv_radius, spot_lights.data[light_index].attenuation, omni_lights.data[light_index].max_energy);
+					float attenuation = get_omni_attenuation(d, spot_lights.data[light_index].inv_radius, spot_lights.data[light_index].attenuation, spot_lights.data[light_index].min_size);
 
 					vec3 spot_dir = spot_lights.data[light_index].direction;
 					float scos = max(dot(-normalize(light_rel_vec), spot_dir), spot_lights.data[light_index].cone_angle);


### PR DESCRIPTION
As discussed on Rocket Chat. This saves a function call in the shader and avoids clamping twice. 